### PR TITLE
モジュールのエクスポートの仕方を確認する

### DIFF
--- a/sample.py
+++ b/sample.py
@@ -1,3 +1,33 @@
-from ss7py import Ss7Py
+from .ss7py import *
 
-Ss7Py.Init()
+
+def main():
+    Init()
+
+    try:
+        Ss7Py.Start(Version.LATEST, ClearLog.CLEAR)
+
+        data = Ss7Py.Open(
+            "C:\\UsrData\\Ss7Data\\sample.ikn",
+            Overwrite.SAVE_NEWNAME,
+            SymbolDuplicate.INTERRUPT,
+        )
+        data.Calculate(Results.RESULT_1, "+必要保有水平耐力")
+
+        res = data.GetResultData(Results.RESULT_1)
+        res.ExportInputCsv(
+            "C:\\UsrData\\Ss7Data\\sample_input.csv",
+            Overwrite.SAVE_NEWNAME,
+            SymbolDuplicate.INTERRUPT,
+        )
+
+        data.Close(Save.SAVE)
+
+    except Exception as e:
+        print(e)
+
+    Ss7Py.End()
+
+
+if __name__ == "__main__":
+    main()

--- a/ss7py/Ss7Py.py
+++ b/ss7py/Ss7Py.py
@@ -82,11 +82,15 @@ class LinkLimitStrengthModel(Enum):
 
 
 class Ss7Data:
+    def __init__(self, data):
+        self.data = data
+
     def GetInputData(self):
         pass
 
     def GetResultData(self, param1):
-        pass
+        data = self.data.GetResultData(param1)
+        return Ss7Result(data)
 
     def Save(self):
         pass
@@ -130,6 +134,7 @@ class Ss7Result:
 
 
 def Init() -> None:
+    """Ss7Python全体の初期化を行う。"""
     Ss7.Init()
 
 
@@ -168,8 +173,9 @@ class Ss7Py:
         pass
 
     @staticmethod
-    def Open(param1, param2, param3):
-        pass
+    def Open(param1, param2, param3) -> Ss7Data:
+        result = Ss7.Open(param1, param2, param3)
+        return Ss7Data(result)
 
     @staticmethod
     def GetLastError():

--- a/ss7py/__init__.py
+++ b/ss7py/__init__.py
@@ -1,3 +1,39 @@
-from .Ss7Py import Ss7Py
+from .Ss7Py import (
+    Init,
+    Ss7Py,
+    # Ss7Data,
+    # Ss7Input,
+    # Ss7Result,
+    Version,
+    ClearLog,
+    PrintMember,
+    Results,
+    Save,
+    Overwrite,
+    SymbolDuplicate,
+    DocumentType,
+    CreateDataCsvOverwrite,
+    ConvertModel,
+    BackupData,
+    LinkLimitStrengthModel,
+)
 
-__all__ = ['Ss7Py']
+__all__ = [
+    "Init",
+    "Ss7Py",
+    # "Ss7Data",
+    # "Ss7Input",
+    # "Ss7Result",
+    "Version",
+    "ClearLog",
+    "PrintMember",
+    "Results",
+    "Save",
+    "Overwrite",
+    "SymbolDuplicate",
+    "DocumentType",
+    "CreateDataCsvOverwrite",
+    "ConvertModel",
+    "BackupData",
+    "LinkLimitStrengthModel",
+]


### PR DESCRIPTION
モジュールのエクスポートと、サンプルコードへのインポートが上手くいっていなかったので確認しました。
Ss7Pyモジュールからエクスポートする必要がありそうな関数・クラス（含Enum）を``__init__.py``にすべて指定しました。